### PR TITLE
Fixes #153

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -4,4 +4,4 @@ use GeneaLabs\LaravelCaffeine\Http\Controllers\Drip;
 
 $dripRoute = config('genealabs-laravel-caffeine.route', 'genealabs/laravel-caffeine/drip');
 
-Route::get($dripRoute, Drip::class.'@drip');
+Route::get($dripRoute, Drip::class.'@drip')->middleware('web');

--- a/src/Providers/Service.php
+++ b/src/Providers/Service.php
@@ -10,15 +10,11 @@ class Service extends ServiceProvider
 {
     public function boot()
     {
-        app('router')->group(app("router")->hasMiddlewareGroup('web')
-            ? ['middleware' => 'web']
-            : [], function () {
-                require __DIR__ . '/../../routes/web.php';
+        $this->loadRoutesFrom(__DIR__.'/../../routes/web.php');
 
-                if (config("app.env") === 'internaltesting') {
-                    require __DIR__ . '/../../tests/routes/web.php';
-                }
-            });
+        if (config("app.env") === 'internaltesting') {
+            $this->loadRoutesFrom(__DIR__.'/../../tests/routes/web.php');
+        }
 
         $configPath = __DIR__ . '/../../config/genealabs-laravel-caffeine.php';
         $this->mergeConfigFrom($configPath, 'genealabs-laravel-caffeine');


### PR DESCRIPTION
The drip route response must have the `XSRF-TOKEN` cookie attached to it. This only happens with the `web`middleware.