### PR TITLE
Remove deprecated reload forceGet attribute

### DIFF
--- a/config/genealabs-laravel-caffeine.php
+++ b/config/genealabs-laravel-caffeine.php
@@ -50,7 +50,7 @@ return [
     | Checking for Lapsed Drips
     |--------------------------------------------------------------------------
     |
-    | If the browser is put to sleep on (for example on mobil devices or
+    | If the browser is put to sleep on (for example on mobile devices or
     | laptops), it will still cause an error when trying to submit the
     | form. To avoid this, we force-reload the form 2 minutes prior
     | to session time-out or later. Setting this setting to 0

--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -35,7 +35,7 @@
     var caffeineReload = function () {
         if (new Date() - lastCheck >= {{ $ageCheckInterval + $ageThreshold }}) {
             setTimeout(function () {
-                location.reload(true);
+                location.reload();
             },  Math.max(0, {{ $ageCheckInterval }} - 500) )
         }
     };


### PR DESCRIPTION
Using `location.reload(true)` causes Firefox to unnecessarily pull all page assets from the origin instead of cache, including images. This `forceGet` attribute is additionally deprecated where it is ignored by most browsers, except in the Firefox case.

By using `location.reload()` instead, the page refresh behavior is made consistent across browsers to properly utilize cached assets while still maintaining package functionality.

References:
- https://developer.mozilla.org/en-US/docs/Web/API/Location/reload
- https://blog.ni18.in/location-reload-is-deprecated/